### PR TITLE
Expose the accumulated positions of the mower

### DIFF
--- a/nodes/mower.js
+++ b/nodes/mower.js
@@ -120,6 +120,7 @@ module.exports = (RED) => {
                   mower: {
                     id: node.autoMower.id,
                     name: node.autoMower.data.system.name,
+                    positions: node.autoMower.data.positions,
                   },
                   payload: {
                     connected: node.autoMower.isConnected,


### PR DESCRIPTION
It seems however, that the API is somewhat broken -- the location updates are every 10 minutes, and only publish a single location point. Even though the plain non-WS api seems to have many more points added in that time frame.

I did write to Husqvarna about this though, so there is a chance that the API deficiency gets fixed and this data reflects the same information as returned by the REST API calls.